### PR TITLE
Update grafana examples to 7.5.3

### DIFF
--- a/examples/grafana/README.md
+++ b/examples/grafana/README.md
@@ -9,7 +9,7 @@ Both Grafana dashboards provide a high-level picture of the request volume and s
 NGINX Service Mesh deploys Grafana and adds `NGINX Mesh Top` as the default dashboard.  If you prefer to use an existing Grafana deployment, you can import either or both example dashboards included in this directory.
 
 ## Prerequisties
-- Grafana version >= 5.2.0
+- Grafana version >= 6.6.0
 - Prometheus datasource must be [configured](https://prometheus.io/docs/visualization/grafana/#creating-a-prometheus-data-source).
   
   **Note:** If you are using the Prometheus server deployed by NGINX Service Mesh you can find the address by running [`nginx-meshctl config`](https://docs.nginx.com/nginx-service-mesh/reference/nginx-meshctl/#usage).

--- a/examples/grafana/nginx-mesh-top.json
+++ b/examples/grafana/nginx-mesh-top.json
@@ -65,9 +65,7 @@
       ],
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "format": "percentunit",
@@ -152,9 +150,7 @@
       ],
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "format": "reqps",
@@ -239,9 +235,7 @@
       ],
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "format": "none",
@@ -322,9 +316,7 @@
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -350,8 +342,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.5",
+      "pluginVersion": "7.5.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -416,9 +411,7 @@
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -444,8 +437,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.5",
+      "pluginVersion": "7.5.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -513,9 +509,7 @@
       "datasource": null,
       "description": "RSS used by NGINX Service Mesh sidecars",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -540,8 +534,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.5",
+      "pluginVersion": "7.5.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -606,9 +603,7 @@
       "datasource": null,
       "description": "Private memory used by NGINX Service Mesh sidecars",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -633,8 +628,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.5",
+      "pluginVersion": "7.5.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -693,7 +691,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "nginx-service-mesh"
@@ -733,5 +731,5 @@
   "timezone": "",
   "title": "NGINX Mesh Top",
   "uid": "N3zQ72OWk",
-  "version": 1
+  "version": 2
 }

--- a/examples/grafana/nginx-service-mesh-summary.json
+++ b/examples/grafana/nginx-service-mesh-summary.json
@@ -1,4 +1,46 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "6.6.0"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -15,8 +57,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 4,
-  "iteration": 1611968770327,
+  "id": null,
+  "iteration": 1618339715410,
   "links": [],
   "panels": [
     {
@@ -36,9 +78,7 @@
     {
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
@@ -52,18 +92,16 @@
         "content": "<div class=\"dashboard-header text-center\">\n<span>Global View</span>\n</div>",
         "mode": "html"
       },
-      "pluginVersion": "7.1.0",
+      "pluginVersion": "7.5.3",
       "timeFrom": null,
       "timeShift": null,
-      "title": "",
       "transparent": true,
       "type": "text"
     },
     {
-      "datasource": "$datasource",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [
             {
               "from": "",
@@ -122,9 +160,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.5",
+      "pluginVersion": "7.5.3",
       "targets": [
         {
           "expr": "sum(irate(nginxplus_upstream_server_responses{code=~\"1xx|2xx\"}[30s])) / sum(irate(nginxplus_upstream_server_responses[30s]))",
@@ -139,10 +178,9 @@
       "type": "stat"
     },
     {
-      "datasource": "$datasource",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [
             {
               "from": "",
@@ -188,9 +226,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.5",
+      "pluginVersion": "7.5.3",
       "targets": [
         {
           "expr": "count(nginxplus_http_requests_total)",
@@ -205,12 +244,9 @@
       "type": "stat"
     },
     {
-      "datasource": "$datasource",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": null
-          },
           "mappings": [
             {
               "from": "",
@@ -261,9 +297,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.5",
+      "pluginVersion": "7.5.3",
       "targets": [
         {
           "expr": "sum(irate(nginxplus_http_requests_total[30s]))",
@@ -294,9 +331,7 @@
     {
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
@@ -310,10 +345,9 @@
         "content": "<div class=\"dashboard-header text-center\">\n<span>Workload View</span>\n</div>",
         "mode": "html"
       },
-      "pluginVersion": "7.1.0",
+      "pluginVersion": "7.5.3",
       "timeFrom": null,
       "timeShift": null,
-      "title": "",
       "transparent": true,
       "type": "text"
     },
@@ -322,36 +356,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": null
-          },
-          "mappings": [
-            {
-              "from": "",
-              "id": 0,
-              "text": "N/A",
-              "to": "",
-              "type": 1,
-              "value": "null"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -378,8 +385,11 @@
       "lines": true,
       "linewidth": 2,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.5",
+      "pluginVersion": "7.5.3",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -415,7 +425,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:388",
           "format": "reqps",
           "label": null,
           "logBase": 1,
@@ -424,7 +433,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:389",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -443,11 +451,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -475,8 +481,11 @@
       "lines": true,
       "linewidth": 2,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.5",
+      "pluginVersion": "7.5.3",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -512,7 +521,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:495",
           "format": "percentunit",
           "label": null,
           "logBase": 1,
@@ -521,7 +529,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:496",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -537,7 +544,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -552,6 +559,8 @@
             "prometheus"
           ]
         },
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Datasource",
@@ -588,5 +597,5 @@
   "timezone": "",
   "title": "NGINX Service Mesh Dashboard",
   "uid": "jeEbxdLMk",
-  "version": 15
+  "version": 1
 }


### PR DESCRIPTION
Update examples to use grafana 7.5.3, up to date with NSM default grafana image version. Also updated the minimum Grafana version because the `nginx-service-mesh-summary.json` file uses a "stat" panel not introduced until 6.6.0.

changed DS_PROMETHEUS to be consistent with the templating in `nginx-service-mesh-summary.json`.