### PR TITLE
Allow FOSSA to run on release branches

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-*
     paths-ignore:
       - 'docs/**'
       - 'examples/**'


### PR DESCRIPTION
In order to track dependencies for a release, we need FOSSA to also scan release branches.

- [x] I have read the [CONTRIBUTING](https://github.com/test-restore/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
