### PR TITLE
Remove deprecated auto-injection references from docs

### DIFF
--- a/docs/content/get-started/configuration.md
+++ b/docs/content/get-started/configuration.md
@@ -132,21 +132,10 @@ NGINX Service Mesh works by injecting a sidecar proxy into Kubernetes resources.
 - [Automatic Injection]( {{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}} )
 - [Manual Injection]( {{< ref "/guides/inject-sidecar-proxy.md#manual-proxy-injection" >}} )
 
-Automatic injection is the default option. This means that any time a user creates a Kubernetes Pod resource, NGINX Service Mesh automatically injects the sidecar proxy into the Pod. 
-
-{{< important >}}
-Automatic injection applies to all namespaces in your Kubernetes cluster. The list of namespaces that you want to use automatic injection for can be updated by using either the NGINX Service Mesh CLI or the REST API. See the [Sidecar Proxy Injection]({{< ref "/guides/inject-sidecar-proxy.md" >}}) topic for more information.
-{{< /important >}}
-
 ## Supported Labels and Annotations
 
 NGINX Service Mesh supports the use of the labels and annotations listed in the tables below.
-
-{{< note >}}
-Each of the labels and annotations listed below are described in more detail in the relevant sections of the NGINX Service Mesh documentation.
-
 If not specified, then the global defaults will be used.
-{{< /note >}}
 
 ### Namespace Labels
 

--- a/docs/content/get-started/install-with-helm.md
+++ b/docs/content/get-started/install-with-helm.md
@@ -53,28 +53,24 @@ helm repo update
 
 ## Installing the Chart
 
-NGINX Service Mesh requires a dedicated namespace for the control plane. You can create this namespace yourself, or allow Helm to create it for you via the `--create-namespace` flag when installing.
+NGINX Service Mesh requires a dedicated namespace for the control plane.
+You can create this namespace yourself, or allow Helm to create it for you via the `--create-namespace` flag when installing.
 
 For information on the container images that NGINX Service Mesh uses, see this section on [Images]( {{< ref "/about/tech-specs.md#images" >}} ).
-
-{{< note >}}
-NGINX Service Mesh control plane Pods may take some time to become Ready once installed. Some Pods may display error logs during the startup process. This typically occurs as the Pods attempt to connect to each other.
-
-Ensure all control plane Pods are in a Ready state before deploying your applications.
-{{< /note >}}
 
 {{< note >}}
 If [Persistent Storage]({{< ref "/get-started/kubernetes-platform/persistent-storage.md" >}}) is not configured in your cluster, set the `mTLS.persistentStorage` field to `off`.
 {{< /note >}}
 
-{{< note >}}
-We recommend deploying the mesh with auto-injection disabled globally, using the `--set disableAutoInjection=true` flag. This ensures that Pods are not automatically injected without your consent, especially in system namespaces.
-You can opt-in the namespaces where you would like auto-injection enabled using the `--set enabledNamespaces={namespace1,namespace2}` flag or by labeling a namespace with `injector.nsm.nginx.com/auto-inject=enabled`.
-{{< /note >}}
+NGINX Service Mesh control plane Pods may take some time to become Ready once installed.
+Some Pods may display error logs during the startup process.
+This typically occurs as the Pods attempt to connect to each other.
 
-{{< note >}}
-OpenShift users: You may see error events related to security contexts while the NGINX Service Mesh control plane is installing. These should resolve themselves as each component becomes ready.
-{{< /note >}}
+OpenShift user may see error events related to security contexts while the NGINX Service Mesh control plane is installing.
+These should resolve themselves as each component becomes ready.
+
+Ensure all control plane Pods are in a Ready state before deploying your applications.
+You can opt-in the namespaces where you would like auto-injection enabled by labeling the namespace with `injector.nsm.nginx.com/auto-inject=enabled`.
 
 ### Install via Repository
 
@@ -173,13 +169,10 @@ After uninstalling, [remove the sidecar proxy from deployments]( {{< ref "/guide
 
 ## Configuration Options
 
-The [values.yaml](https://github.com/nginxinc/nginx-service-mesh/blob/main/helm-chart/values.yaml) file within the `nginx-service-mesh` Helm chart contains the deployment configuration for NGINX Service Mesh. These configuration fields map directly to the `nginx-meshctl deploy` command-line options mentioned throughout our documentation. More details about these options can be found in the [Configuration]( {{< ref "/get-started/configuration.md" >}} ) guide. You can update these fields directly in the `values.yaml` file, or by specifying the `--set` flag when running `helm install`.
-
-{{< note >}}
-Helm uses `{}` to denote array values.
-
-Example: `--set enabledNamespaces={namespace1,namespace2}`
-{{< /note >}}
+The [values.yaml](https://github.com/nginxinc/nginx-service-mesh/blob/main/helm-chart/values.yaml) file within the `nginx-service-mesh` Helm chart contains the deployment configuration for NGINX Service Mesh.
+These configuration fields map directly to the `nginx-meshctl deploy` command-line options mentioned throughout our documentation.
+More details about these options can be found in the [Configuration]( {{< ref "/get-started/configuration.md" >}} ) guide.
+You can update these fields directly in the `values.yaml` file, or by specifying the `--set` flag when running `helm install`.
 
 The following table lists the configurable parameters of the NGINX Service Mesh chart and their default values.
 
@@ -200,8 +193,6 @@ The following table lists the configurable parameters of the NGINX Service Mesh 
 | `nginxLogFormat` | NGINX log format. | default |
 | `nginxLBMethod` | NGINX load balancing method. | least_time |
 | `clientMaxBodySize` | NGINX client max body size. Setting to "0" disables checking of client request body size. | 1m |
-| `disableAutoInjection` | Globally disable automatic sidecar injection upon resource creation. Use either "enabledNamespaces" or a namespace label to enable automatic injection. | false |
-| `enabledNamespaces` | Enable automatic sidecar injection for specific namespaces. Must be used with `disable`. | [] |
 | `prometheusAddress` | The address of a Prometheus server deployed in your Kubernetes cluster. Address should be in the format `<service-name>.<namespace>:<service-port>`. | "" |
 | `telemetry.samplerRatio` | The percentage of traces that are processed and exported to the telemetry backend. Float between 0 and 1. | 0.01 |
 | `telemetry.exporters` | The configuration of exporters to send telemetry data to. | |

--- a/docs/content/get-started/install.md
+++ b/docs/content/get-started/install.md
@@ -131,11 +131,6 @@ Take the steps below to install the NGINX Service Mesh control plane.
     nginx-meshctl deploy
     ```
 
-   {{< note >}}
-   We recommend deploying the mesh with auto-injection disabled globally, using the `--disable-auto-inject` flag. This ensures that Pods are not automatically injected without your consent, especially in system namespaces.
-   You can enable auto-injection in specific namespaces using  `--enabled-namespaces "namespace-1,namespace-2"` or by labeling a namespace with `injector.nsm.nginx.com/auto-inject=enabled`.
-   {{< /note >}}
-
 2. Verify the pods are running.
 
     ```bash
@@ -154,10 +149,10 @@ Take the steps below to install the NGINX Service Mesh control plane.
 
 ## UDP MTU Sizing
 
-{{< note >}}
 UDP traffic proxying is turned off by default. You can activate it at deploy time using the `--enable-udp` flag. Linux kernel 4.18 or greater is required.
-{{< /note >}}
 
-NGINX Service Mesh automatically detects and adjusts the `eth0` interface to support the 32 bytes of space required for PROXY Protocol V2. See the [UDP and eBPF architecture]({{< ref "architecture.md#udp-and-ebpf" >}}) section for more information.
+NGINX Service Mesh automatically detects and adjusts the `eth0` interface to support the 32 bytes of space required for PROXY Protocol V2.
+See the [UDP and eBPF architecture]({{< ref "architecture.md#udp-and-ebpf" >}}) section for more information.
 
-NGINX Service Mesh does not detect changes made to the MTU in the pod at runtime. If adding a CNI changes the MTU of the `eth0` interface of running pods, you should re-roll the affected pods to ensure those changes take place.
+NGINX Service Mesh does not detect changes made to the MTU in the pod at runtime.
+If adding a CNI changes the MTU of the `eth0` interface of running pods, you should re-roll the affected pods to ensure those changes take place.

--- a/docs/content/get-started/openshift-platform/considerations.md
+++ b/docs/content/get-started/openshift-platform/considerations.md
@@ -20,10 +20,8 @@ Using a CSI Driver comes with some considerations for the user on installation a
 
 The NGINX Service Mesh deployment experience is the exact same as in other environments. Simply add the `--environment openshift` flag when deploying the mesh, and the CSI Driver and security context constraints will be set up for you.
 
-To avoid conflicting with regular OpenShift operations and operators running in other environments, we recommended limiting NGINX Service Mesh injection to Pods running in a designated project or set of projects:
-
 ```bash
-nginx-meshctl deploy ... --environment openshift --disable-auto-inject --enabled-namespaces="<your-project1>,<your-project2>"
+nginx-meshctl deploy ... --environment openshift"
 ```
 
 ### Remove

--- a/docs/content/guides/monitoring-and-tracing.md
+++ b/docs/content/guides/monitoring-and-tracing.md
@@ -12,25 +12,19 @@ docs: "DOCS-693"
 
 NGINX Service Mesh can integrate with your Prometheus, Grafana, and tracing backends for exporting metrics and tracing data.
 
-{{< see-also >}}
-If you do not have your own Prometheus, Grafana, or tracing backends deployed, the [Observability Tutorial]( {{< ref "/tutorials/observability.md" >}}) will deploy and integrate a basic demo setup for you.
-{{< /see-also >}}
-
-### Prometheus
+If you do not have Prometheus, Grafana, or tracing backends deployed, you can follow the [Observability Tutorial]( {{< ref "/tutorials/observability.md" >}}) to deploy a basic demo setup.
 
 {{< important >}}
-In order to prevent automatic sidecar injection into your Prometheus deployment, it should be deployed in a namespace where auto-injection is disabled, or the `injector.nsm.nginx.com/auto-inject: disabled` label must be added to the *PodTemplateSpec* of the Prometheus deployment.
-
-Another option is to disable auto injection globally when deploying the mesh.
-
-Refer to [NGINX Service Mesh Labels and Annotations]( {{< ref "/get-started/configuration.md#supported-labels-and-annotations" >}}) for more information.
+In order to prevent automatic sidecar injection into your Prometheus, Grafana, and tracing deployments, they should be deployed in a namespace where auto-injection is disabled. Alternatively, you can disable auto-injection for these deployments specifically by adding the `injector.nsm.nginx.com/auto-inject: disabled` label to the *PodTemplateSpec* of the deployments.
 {{< /important >}}
 
-To use NGINX Service Mesh with your Prometheus deployment:
+### Prometheus
 
 {{< warning >}}
 We do not currently support Prometheus deployments running with TLS encryption.
 {{< /warning>}}
+
+To use NGINX Service Mesh with your Prometheus deployment:
 
 1. Connect your existing Prometheus Deployment to NGINX Service Mesh:
 
@@ -63,8 +57,8 @@ We do not currently support Prometheus deployments running with TLS encryption.
       ```
 
 1. Add the `nginx-mesh-sidecars` scrape config to your Prometheus configuration.
-
-   {{< note >}}If you are deploying NGINX Plus Ingress Controller with the NGINX Service Mesh, add the `nginx-plus-ingress` scrape config as well. Consult the [Metrics]( {{< ref "/tutorials/kic/deploy-with-kic.md#nginx-plus-ingress-controller-metrics" >}} ) section of the NGINX Ingress Controller Deployment tutorial for more information about the metrics collected.{{< /note >}}
+   If you are deploying NGINX Plus Ingress Controller with the NGINX Service Mesh, add the `nginx-plus-ingress` scrape config as well.
+   Consult the [Metrics]( {{< ref "/tutorials/kic/deploy-with-kic.md#nginx-plus-ingress-controller-metrics" >}} ) section of the NGINX Ingress Controller Deployment tutorial for more information about the metrics collected.
 
    - {{< fa "download" >}} {{< link "/examples/nginx-mesh-sidecars-scrape-config.yaml" "`nginx-mesh-sidecars-scrape-config.yaml`" >}}
    - {{< fa "download" >}} {{< link "/examples/nginx-plus-ingress-scrape-config.yaml" "`nginx-plus-ingress-scrape-config.yaml`" >}}
@@ -77,27 +71,12 @@ For more information on how to view and understand the metrics that we track, se
 The custom NGINX Service Mesh Grafana dashboard `NGINX Mesh Top` can be imported into your Grafana instance. 
 For instructions and a list of features, see the [Grafana example](https://github.com/nginxinc/nginx-service-mesh/tree/main/examples/grafana) in the `nginx-service-mesh` GitHub repo.
 
-{{< important >}}
-In order to prevent automatic sidecar injection into your Grafana deployment, it should be deployed in a namespace where auto-injection is disabled, or the `injector.nsm.nginx.com/auto-inject: disabled` label must be added to the *PodTemplateSpec* of the Grafana deployment.
-
-Another option is to disable auto injection globally when deploying the mesh.
-
-Refer to [NGINX Service Mesh Labels and Annotations]( {{< ref "/get-started/configuration.md#supported-labels-and-annotations" >}}) for more information.
-{{< /important >}}
 
 ### Tracing with OpenTelemetry
 
 NGINX Service Mesh can export tracing data using `OpenTelemetry`. Tracing data can be exported to an OpenTelemetry Protocol (OTLP) gRPC Exporter, such as the [OpenTelemetry (OTEL) Collector](https://opentelemetry.io/docs/collector/), which can then export data to one or more upstream collectors like [Jaeger](https://www.jaegertracing.io/), [DataDog](https://docs.datadoghq.com/tracing/), [LightStep](https://lightstep.com/), or many others. Before installing the mesh, deploy an OTEL Collector that is [configured to export data](https://opentelemetry.io/docs/collector/configuration/#exporters) to an upstream collector that you have already deployed or have access to.
 
 Tracing relies on the trace headers passed through each microservice in an application in order to build a full trace of a request. If you don't configure your app to pass trace headers, you'll get disjointed traces that are more difficult to understand. See the [OpenTelemetry Instrumentation](https://opentelemetry.io/docs/instrumentation/) guide for information on how to instrument your application to pass trace headers.
-
-{{< important >}}
-In order to prevent automatic sidecar injection into your tracing deployments, it should be deployed in a namespace where auto-injection is disabled, or the `injector.nsm.nginx.com/auto-inject: disabled` label must be added to the *PodTemplateSpec* of the deployments.
-
-Another option is to disable auto injection globally when deploying the mesh.
-
-Refer to [NGINX Service Mesh Labels and Annotations]( {{< ref "/get-started/configuration.md#supported-labels-and-annotations" >}}) for more information.
-{{< /important >}}
 
 - *At deployment*:
 

--- a/docs/content/guides/secure-traffic-mtls.md
+++ b/docs/content/guides/secure-traffic-mtls.md
@@ -249,19 +249,20 @@ We'll use the [Istio `bookinfo`](https://istio.io/docs/examples/bookinfo/) examp
 
 - {{< fa "download" >}} {{< link "/examples/bookinfo.yaml" "`bookinfo.yaml`" >}}
 
-1. First, deploy the `bookinfo` application:
+1. Enable [automatic sidecar injection]( {{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}} ) for the `default` namespace.
+1. Deploy the `bookinfo` application:
 
     ```bash
     kubectl apply -f bookinfo.yaml
     ```
 
-2. To access `bookinfo`, set up port-forwarding:
+1. To access `bookinfo`, set up port-forwarding:
 
     ```bash
     kubectl port-forward svc/productpage 9080
     ```
 
-3. Finally, navigate to `http://localhost:9080` in a browser. On the front side, it uses clear text. All of the service-to-service calls will be SSL-encrypted.
+1. Finally, navigate to `http://localhost:9080` in a browser. On the front side, it uses clear text. All of the service-to-service calls will be SSL-encrypted.
 
 
 ### Debug mTLS Issues

--- a/docs/content/guides/upgrade.md
+++ b/docs/content/guides/upgrade.md
@@ -20,7 +20,7 @@ Incompatibilities between previous and current versions may require specific ste
 - [Manual Upgrade](#manual-upgrade)
 - [Upgrade to 1.7.0 in OpenShift](#upgrade-to-170-in-openshift)
 
-{< important >}}
+{{< important >}}
 When upgrading from NGINX Service Mesh prior to v1.7, any tracing settings that do not correspond to an OpenTelemetry configuration will be removed. To deploy OpenTelemetry services and configure your mesh for OpenTelemetry tracing refer to the [Monitoring and Tracing]( {{< ref "/guides/monitoring-and-tracing.md" >}} ) guide.
 {{< /important >}}
 

--- a/docs/content/reference/api/api-usage.md
+++ b/docs/content/reference/api/api-usage.md
@@ -187,45 +187,12 @@ You can PATCH the configuration of NGINX Service Mesh by sending a request to th
 
 - REST API endpoint: `/apis/nsm.nginx.com/v1alpha1/config`
 
-The supported patch operations are:
+The supported patch operation is:
 
-- `add`
-- `remove`
 - `replace`
 
-There are a subset of fields and objects supported for add, remove, and replace. Refer to the PATCH config schema described above for the full reference, the following examples can be referred to for a quick start.
-
-#### Example: Disable Automatic injection in All Namespaces
-
-The payload shown below disables automatic injection of the sidecar proxy for all namespaces and enables it for only the "prod" and "staging" namespaces.
-
-```json
-[
-    {
-        "op": "replace",
-        "field": {
-            "isAutoInjectEnabled": false
-        }
-    },
-    {
-        "op": "add",
-        "field": {
-            "enabledNamespaces": ["prod", "staging"]
-        }
-    }
-]
-```
-
-To `remove` all values from a list of strings, define the value as an empty list (using `replace` with an empty list will have the same effect). For example:
-
-```json
-{
-    "op": "remove",
-    "field": {
-        "enabledNamespaces": []
-    }
-}
-```
+There are a subset of fields and objects supported for replacement.
+Refer to the PATCH config schema described above for details.
   
 ### Internal Configuration API Endpoints
 

--- a/docs/content/reference/nginx-meshctl.md
+++ b/docs/content/reference/nginx-meshctl.md
@@ -100,12 +100,8 @@ Flags:
       --access-control-mode string        default access control mode for service-to-service communication
                                           		Valid values: allow, deny (default "allow")
       --client-max-body-size string       NGINX client max body size (default "1m")
-      --disable-auto-inject               disable automatic sidecar injection upon resource creation
-                                          		Use the --enabled-namespaces flag to enable automatic injection in select namespaces
       --disable-public-images             don't pull third party images from public repositories
       --enable-udp                        enable UDP traffic proxying (beta); Linux kernel 4.18 or greater is required
-      --enabled-namespaces strings        enable automatic sidecar injection for specific namespaces
-                                          		Must be used with --disable-auto-inject
       --environment string                environment to deploy the mesh into
                                           		Valid values: kubernetes, openshift (default "kubernetes")
   -h, --help                              help for deploy
@@ -163,13 +159,9 @@ Most of the examples below show shortened commands for convenience. The '...' in
 
     `nginx-meshctl deploy ... --namespace my-namespace`
 
-- Deploy the Service Mesh with mTLS and automatic injection turned off:
+- Deploy the Service Mesh with mTLS turned off:
 
-    `nginx-meshctl deploy ... --mtls-mode off --disable-auto-inject`
-
-- Deploy the Service Mesh and only allow automatic injection in namespace "my-namespace":
-
-    `nginx-meshctl deploy ... --disable-auto-inject --enabled-namespaces="my-namespace"`
+    `nginx-meshctl deploy ... --mtls-mode off`
 
 - Deploy the Service Mesh and enable telemetry traces to be exported to your OTLP gRPC collector running in your Kubernetes cluster:
      

--- a/docs/content/tutorials/accesscontrol-walkthrough.md
+++ b/docs/content/tutorials/accesscontrol-walkthrough.md
@@ -15,12 +15,9 @@ The access control mode can be [set to `deny` at the global level]( {{< ref "/ge
 ## Before You Begin
 
 1. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-2. [Deploy NGINX Service Mesh]({{< ref "/get-started/install.md" >}}) in your Kubernetes cluster.
-   {{< note >}}
-   This guide assumes that automatic injection is activated either cluster-wide or for the `default` namespace.
-   If you have disabled automatic injection, you must [manually inject]({{< ref "/guides/inject-sidecar-proxy.md" >}}) the application resources before creating them.
-   {{< /note >}}
-3. Download all of the example files:
+1. [Deploy NGINX Service Mesh]({{< ref "/get-started/install.md" >}}) in your Kubernetes cluster.
+1. Enable [automatic sidecar injection]( {{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}} ) for the `default` namespace.
+1. Download all of the example files:
 
     - {{< fa "download" >}} {{< link "/examples/dest-svc.yaml" >}}
     - {{< fa "download" >}} {{< link "/examples/access.yaml" >}}
@@ -54,9 +51,7 @@ ServiceAccount resources are used to classify sets of workloads for access contr
     dest-svc-69f4b86fb4-r8wzh            2/2     Running   0          2m
     ```
 
-    {{< note>}}
-For other resource types -- for example, Deployments, ConfigMaps, Services, or ServiceAccounts -- use `kubectl get` for each type as appropriate.
-    {{< /note>}}
+    For other resource types -- for example, Deployments, ConfigMaps, Services, or ServiceAccounts -- use `kubectl get` for each type as appropriate.
 
 1. Once the destination workload is ready, we can generate unfiltered traffic. Use a separate terminal window in order to watch traffic flow as a request driver begins sending requests.
 

--- a/docs/content/tutorials/deploy-example-app.md
+++ b/docs/content/tutorials/deploy-example-app.md
@@ -33,19 +33,18 @@ Ensure that you have deployed Prometheus, Grafana, and a tracing backend and con
 
 ## Inject the Sidecar Proxy
 
-You can use either automatic injection or manual injection to add the NGINX Service Mesh sidecar containers to your application pods.
-
-{{< tip>}}
-
-- [Automatic proxy injection]( {{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}} ) (enabled by default)
-- [Manual proxy injection]( {{< ref "/guides/inject-sidecar-proxy.md#manual-proxy-injection" >}} )
-
-{{< /tip>}}
+You can use either [automatic]( {{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}} ) or [manual injection]( {{< ref "/guides/inject-sidecar-proxy.md#manual-proxy-injection" >}} ) to add the NGINX Service Mesh sidecar containers to your application pods.
 
 ### Inject the Sidecar Proxy Automatically
 
-Since NGINX Service Mesh uses automatic injection by default, you just need to use `kubectl` to apply your Deployment.
-The sidecar proxy runs automatically.
+To enable automatic sidecar injection for all Pods in a namespace, add the `injector.nsm.nginx.com/auto-inject=enabled` label to the namespace.
+
+```bash
+kubectl label namespaces default injector.nsm.nginx.com/auto-inject=enabled
+```
+
+With auto-injection enabled, you can use `kubectl` to apply your Deployment as normal.
+The sidecar proxy will be added and runs automatically.
 
 ```bash
 kubectl apply -f examples/bookinfo.yaml

--- a/docs/content/tutorials/kic/egress-walkthrough.md
+++ b/docs/content/tutorials/kic/egress-walkthrough.md
@@ -40,14 +40,14 @@ If you want to view metrics for NGINX Ingress Controller, ensure that you have d
 
 1. Follow the installation [instructions]( {{< ref "/get-started/install.md" >}} ) to install NGINX Service Mesh on your Kubernetes cluster.
     
-    - When deploying the mesh set the [mTLS mode]( {{< ref "/guides/secure-traffic-mtls.md" >}} ) to `strict`  and [disable global auto-injection]( {{< ref "/guides/inject-sidecar-proxy.md#enable-or-disable-automatic-proxy-injection-by-namespace">}} ). Make sure not to add the `legacy` namespace as an enabled namespace.
+    - When deploying the mesh set the [mTLS mode]( {{< ref "/guides/secure-traffic-mtls.md" >}} ) to `strict`.
     - Your deploy command should contain the following flags:
     
       ```bash
-      nginx-meshctl deploy ... --mtls-mode=strict --disable-auto-inject --enabled-namespaces "default"
+      nginx-meshctl deploy ... --mtls-mode=strict
       ```
 
-1. Get the config of the mesh and verify that `mtls.mode` is `strict` and `enabledNamespaces` does not contain the `legacy` namespace:
+1. Get the config of the mesh and verify that `mtls.mode` is `strict`:
 
     ```bash
     nginx-meshctl config 
@@ -83,7 +83,8 @@ The `target` application is a basic NGINX server listening on port 80. It return
 
 ### Send traffic to the target application
 
-1. Create the `sender` application in the default namespace:
+1. Enable [automatic sidecar injection]( {{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}} ) for the `default` namespace.
+1. Create the `sender` application in the `default` namespace:
 
     ```bash
     kubectl apply -f egress-driver.yaml

--- a/docs/content/tutorials/kic/ingress-udp-walkthrough.md
+++ b/docs/content/tutorials/kic/ingress-udp-walkthrough.md
@@ -16,7 +16,6 @@ Objectives:
 - Deploy NGINX Service Mesh.
 - Install NGINX Ingress Controller.
 - Deploy the example `udp-listener` app.
-  - {{< fa "download" >}} {{< link "/examples/nginx-ingress-controller/udp/udp-listener.yaml" "udp-listener.yaml" >}}
 - Create a Kubernetes GlobalConfiguration resource to establish a NGINX Ingress Controller UDP listener.
 - Create a Kubernetes TransportServer resource for the udp-listener application.
 
@@ -69,27 +68,27 @@ NGINX Ingress Controller will try to fetch certs from the Spire agent that gets 
 
     We'll use `12.115.30.1`.
  
- {{< note >}}
- At this point, you should have the NGINX Ingress Controller running in your cluster; you can deploy the udp-listener example app to test out the mesh integration, or use NGINX Ingress controller to expose one of your own apps. 
- {{< /note >}}
+
+ At this point, you should have the NGINX Ingress Controller running in your cluster; you can deploy the udp-listener example app to test out the mesh integration, or use NGINX Ingress controller to expose one of your own apps.
 
 ### Deploy the udp-listener App
 
-Use `kubectl` to deploy the example `udp-listener` app.  
+1. Enable [automatic sidecar injection]( {{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}} ) for the `default` namespace.
+1. Download the manifest for the `udp-listener` app.
+    - {{< fa "download" >}} {{< link "/examples/nginx-ingress-controller/udp/udp-listener.yaml" "udp-listener.yaml" >}}
+1. Use `kubectl` to deploy the example `udp-listener` app.
 
-If [automatic injection]( {{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}} ) is enabled, NGINX Service Mesh will inject the sidecar proxy into the application pods automatically. Otherwise, use [manual injection]( {{< ref "/guides/inject-sidecar-proxy.md#manual-proxy-injection" >}} ) to inject the sidecar proxies.
+    ```bash
+    kubectl apply -f udp-listener.yaml
+    ```
 
-```bash
-kubectl apply -f udp-listener.yaml
-```
+1. Verify that all of the Pods are ready and in "Running" status:
 
-Verify that all of the Pods are ready and in "Running" status:
-
-```bash
-kubectl get pod
-NAME                            READY   STATUS    RESTARTS   AGE
-udp-listener-59665d7ffc-drzh2   2/2     Running   0          4s
-```
+    ```bash
+    kubectl get pod
+    NAME                            READY   STATUS    RESTARTS   AGE
+    udp-listener-59665d7ffc-drzh2   2/2     Running   0          4s
+    ```
 
 ### Expose the udp-listener App
 

--- a/docs/content/tutorials/kic/ingress-walkthrough.md
+++ b/docs/content/tutorials/kic/ingress-walkthrough.md
@@ -10,18 +10,14 @@ docs: "DOCS-723"
 ## Overview
 
 Follow this tutorial to deploy the NGINX Ingress Controller with NGINX Service Mesh and an example application.
+All communication between the NGINX Ingress Controller and the example application will occur over mTLS.
 
 Objectives:
 
 - Deploy the NGINX Service Mesh.
 - Install NGINX Ingress Controller.
 - Deploy the example `bookinfo` app.
-  - {{< fa "download" >}} {{< link "/examples/bookinfo.yaml" >}}
 - Create a Kubernetes Ingress resource for the Bookinfo application.
-
-{{< note >}}
-All communication between the NGINX Ingress Controller and the Bookinfo application occurs over mTLS.
-{{< /note >}}
 
 {{< note >}}
 NGINX Ingress Controller can be used for free with NGINX Open Source. Paying customers have access to NGINX Ingress Controller with NGINX Plus.
@@ -34,17 +30,13 @@ To complete this tutorial, you must use either:
 
 ### Install NGINX Service Mesh
 
-{{< note >}}
 If you want to view metrics for NGINX Ingress Controller, ensure that you have deployed Prometheus and Grafana and then configure NGINX Service Mesh to integrate with them when installing. Refer to the [Monitoring and Tracing]( {{< ref "/guides/monitoring-and-tracing.md" >}} ) guide for instructions.
-{{< /note >}}
 
 Follow the installation [instructions]( {{< ref "/get-started/install.md" >}} ) to install NGINX Service Mesh on your Kubernetes cluster.
 You can either deploy the Mesh with the default value for [mTLS mode]( {{< ref "/guides/secure-traffic-mtls.md" >}} ), which is `permissive`, or set it to `strict`.
 
-{{< caution >}} 
 Before proceeding, verify that the mesh is running (Step 2 of the installation [instructions]( {{< ref "/get-started/install.md" >}} )).
-NGINX Ingress Controller will try to fetch certs from the Spire agent that gets deployed by NGINX Service Mesh on startup. If the mesh is not running, NGINX Ingress controller will fail to start.  
-{{< /caution >}}
+NGINX Ingress Controller will try to fetch certs from the Spire agent that gets deployed by NGINX Service Mesh on startup. If the mesh is not running, NGINX Ingress controller will fail to start.
 
 ### Install NGINX Ingress Controller
 
@@ -58,36 +50,35 @@ NGINX Ingress Controller will try to fetch certs from the Spire agent that gets 
     nginx-ingress   LoadBalancer   10.76.7.165   34.94.247.235   80:31287/TCP,443:31923/TCP   66s
     ```
  
- {{< note >}}
- At this point, you should have the NGINX Ingress Controller running in your cluster; you can deploy the Bookinfo example app to test out the mesh integration, or use NGINX Ingress controller to expose one of your own apps. 
- {{< /note >}}
+ At this point, you should have the NGINX Ingress Controller running in your cluster; you can deploy the Bookinfo example app to test out the mesh integration, or use NGINX Ingress controller to expose one of your own apps.
 
 ### Deploy the Bookinfo App
 
-Use `kubectl` to deploy the example `bookinfo` app.  
+1. Enable [automatic sidecar injection]( {{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}} ) for the `default` namespace.
+1. Download the manifest for the `bookinfo` app.
+    - {{< fa "download" >}} {{< link "/examples/bookinfo.yaml" "bookinfo.yaml" >}}
+1. Use `kubectl` to deploy the example `bookinfo` app.
 
-If [automatic injection]( {{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}} ) is enabled, NGINX Service Mesh will inject the sidecar proxy into the application pods automatically. Otherwise, use [manual injection]( {{< ref "/guides/inject-sidecar-proxy.md#manual-proxy-injection" >}} ) to inject the sidecar proxies.
+    ```bash
+    kubectl apply -f bookinfo.yaml
+    ```
 
-```bash
-kubectl apply -f bookinfo.yaml
-```
+1. Verify that all of the Pods are ready and in "Running" status:
 
-Verify that all of the Pods are ready and in "Running" status:
+    ```bash
+    kubectl get pods
 
-```bash
-kubectl get pods
+    NAME                              READY   STATUS    RESTARTS   AGE
+    details-v1-74f858558f-khg8t       2/2     Running   0          25s
+    productpage-v1-8554d58bff-n4r85   2/2     Running   0          24s
+    ratings-v1-7855f5bcb9-zswkm       2/2     Running   0          25s
+    reviews-v1-59fd8b965b-kthtq       2/2     Running   0          24s
+    reviews-v2-d6cfdb7d6-h62cb        2/2     Running   0          24s
+    reviews-v3-75699b5cfb-9jtvq       2/2     Running   0          24s
 
-NAME                              READY   STATUS    RESTARTS   AGE
-details-v1-74f858558f-khg8t       2/2     Running   0          25s
-productpage-v1-8554d58bff-n4r85   2/2     Running   0          24s
-ratings-v1-7855f5bcb9-zswkm       2/2     Running   0          25s
-reviews-v1-59fd8b965b-kthtq       2/2     Running   0          24s
-reviews-v2-d6cfdb7d6-h62cb        2/2     Running   0          24s
-reviews-v3-75699b5cfb-9jtvq       2/2     Running   0          24s
+    ```
 
-```
-
-Optionally, verify that the application works:
+(Optional) Verify that the application works:
 
 {{< note >}}
 The steps in this section only work with `permissive` [mTLS mode]( {{< ref "/guides/secure-traffic-mtls.md" >}} ). With `strict` mTLS mode, the sidecar will drop all traffic that is not encrypted with a certificate issued by NGINX Service Mesh, so the below steps won't work. For `strict` mTLS mode skip forward to the next section which covers how to [Expose the Bookinfo App](#expose-the-bookinfo-app).
@@ -110,7 +101,7 @@ Create an Ingress Resource to expose the Bookinfo application, using the example
 If using Kubernetes v1.18.0 or greater you must use `ingressClassName` in your Ingress resources. Uncomment line 6 in the resource below or the downloaded file, `bookinfo-ingress.yaml`.
 {{< /important >}}
 
-- {{< fa "download" >}} {{< link "/examples/nginx-ingress-controller/bookinfo-ingress.yaml" "`bookinfo-ingress.yaml`" >}}
+- {{< fa "download" >}} {{< link "/examples/nginx-ingress-controller/bookinfo-ingress.yaml" "bookinfo-ingress.yaml" >}}
 
 ```bash
 kubectl apply -f bookinfo-ingress.yaml

--- a/docs/content/tutorials/observability.md
+++ b/docs/content/tutorials/observability.md
@@ -27,7 +27,7 @@ Deploy the components:
 kubectl apply -f prometheus.yaml -f grafana.yaml -f otel-collector.yaml -f jaeger.yaml
 ```
 
-This command creates the `nsm-monitoring` namespace and deploys all of the components in that namespace.
+This command creates the `nsm-monitoring` namespace and deploys all of the components in that namespace. This namespace does not have the auto-inject label because we do not want to inject the sidecar into the observability deployments.
 
 ## Install NGINX Service Mesh
 
@@ -36,7 +36,7 @@ Install NGINX Service Mesh and configure it to integrate with the observability 
 Using the CLI:
 
 ```bash
-nginx-meshctl deploy --prometheus-address "prometheus.nsm-monitoring.svc:9090" --telemetry-exporters "type=otlp,host=otel-collector.nsm-monitoring.svc,port=4317" --telemetry-sampler-ratio 1 --disable-auto-inject --enabled-namespaces "default"
+nginx-meshctl deploy --prometheus-address "prometheus.nsm-monitoring.svc:9090" --telemetry-exporters "type=otlp,host=otel-collector.nsm-monitoring.svc,port=4317" --telemetry-sampler-ratio 1
 ```
 
 Using Helm:
@@ -45,7 +45,7 @@ Using Helm:
 helm repo add nginx-stable https://helm.nginx.com/stable
 helm repo update
 
-helm install nsm nginx-stable/nginx-service-mesh --namespace nginx-mesh --create-namespace --wait --set prometheusAddress=prometheus.nsm-monitoring.svc:9090 --set telemetry.exporters.otlp.host=otel-collector.nsm-monitoring.svc --set telemetry.exporters.otlp.port=4317 --set telemetry.samplerRatio=1  --set disableAutoInjection=true --set enabledNamespaces={"default"}
+helm install nsm nginx-stable/nginx-service-mesh --namespace nginx-mesh --create-namespace --wait --set prometheusAddress=prometheus.nsm-monitoring.svc:9090 --set telemetry.exporters.otlp.host=otel-collector.nsm-monitoring.svc --set telemetry.exporters.otlp.port=4317 --set telemetry.samplerRatio=1
 ```
 
 {{< note >}}

--- a/docs/content/tutorials/ratelimit-walkthrough.md
+++ b/docs/content/tutorials/ratelimit-walkthrough.md
@@ -21,12 +21,9 @@ This tutorial shows you how to set up rate limiting policies between your worklo
 ## Before You Begin
 
 1. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-2. [Deploy NGINX Service Mesh]({{< ref "/get-started/install.md" >}}) in your Kubernetes cluster.
-   {{< note >}}
-   This guide assumes that automatic injection is activated either cluster-wide or for the `default` namespace.
-   If you have disabled automatic injection, you must [manually inject]({{< ref "/guides/inject-sidecar-proxy.md#manual-proxy-injection" >}}) the application resources before creating them.
-   {{< /note >}}
-3. Download all of the example files:
+1. [Deploy NGINX Service Mesh]({{< ref "/get-started/install.md" >}}) in your Kubernetes cluster.
+1. Enable [automatic sidecar injection]( {{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}} ) for the `default` namespace.
+1. Download all of the example files:
 
     - {{< fa "download" >}} {{< link "/examples/rate-limit/destination.yaml" "`destination.yaml`" >}}
     - {{< fa "download" >}} {{< link "/examples/rate-limit/client-v1.yaml" "`client-v1.yaml`" >}}

--- a/docs/content/tutorials/trafficsplit-deployments.md
+++ b/docs/content/tutorials/trafficsplit-deployments.md
@@ -14,14 +14,12 @@ You can use traffic splitting for most deployment scenarios, including canary, b
 ## Before You Begin
 
 1. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-1. Set up a Kubernetes cluster with [NGINX Service Mesh]( {{< ref "/get-started/install.md" >}} ) deployed. This guide assumes that automatic injection is activated either cluster-wide or for the `default` namespace.
-   If you have automatic injection turned off, you must [manually inject]({{< ref "/guides/inject-sidecar-proxy.md#manual-proxy-injection" >}}) the application resources before creating them.
-   {{< note >}}
-   This tutorial assumes traffic can be sent to injected Pods and Services without mTLS sessions. For the purposes of this tutorial NGINX Service Mesh must be deployed with `--mtls-mode` in the `permissive` or `off` states.
-   {{< /note >}}
-   {{< note >}}
-   If you want to view metrics, ensure that you have deployed Prometheus and Grafana and then configure NGINX Service Mesh to integrate with them when installing. Refer to the [Monitoring and Tracing]( {{< ref "/guides/monitoring-and-tracing.md" >}} ) guide for instructions.
-   {{< /note >}}
+1. (Optional) If you want to view metrics, ensure that you have deployed Prometheus and Grafana.
+  Refer to the [Monitoring and Tracing]( {{< ref "/guides/monitoring-and-tracing.md" >}} ) guide for instructions.
+1. Set up a Kubernetes cluster with [NGINX Service Mesh]( {{< ref "/get-started/install.md" >}} ) deployed with the following configuration:
+    - `--mtls-mode` is set to `permissive` or `off` states.
+    - (Optional) `--prometheus-address` is pointed to the Prometheus instance you created above.
+1. Enable [automatic sidecar injection]( {{< ref "/guides/inject-sidecar-proxy.md#automatic-proxy-injection" >}} ) for the `default` namespace.
 1. Download all the example files:
 
     - {{< fa "download" >}} {{< link "/examples/traffic-split/gateway.yaml" "gateway.yaml" >}}

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -1,11 +1,11 @@
 # NGINX Service Mesh
 
-Before deploying NGINX Service Mesh, see the [Platform Guide](https://docs.nginx.com/nginx-service-mesh/get-started/kubernetes-platform/) to ensure your environment is properly configured. If [Persistent Storage](https://docs.nginx.com/nginx-service-mesh/get-started/kubernetes-platform/persistent-storage/) is not configured in your cluster, set the `mTLS.persistentStorage` field to `off`. Verify that no other service meshes exist in your Kubernetes cluster. It is advised to install NGINX Service Mesh in a dedicated namespace.
+Before deploying NGINX Service Mesh, see the [Platform Guide](https://docs.nginx.com/nginx-service-mesh/get-started/kubernetes-platform/) to ensure your environment is properly configured.
+If [Persistent Storage](https://docs.nginx.com/nginx-service-mesh/get-started/kubernetes-platform/persistent-storage/) is not configured in your cluster, set the `mTLS.persistentStorage` field to `off`.
+Verify that no other service meshes exist in your Kubernetes cluster. It is advised to install NGINX Service Mesh in a dedicated namespace.
 
 ## Helm Installation and Configuration
 
 For information on the configuration options and installation process when using Helm with NGINX Service Mesh, see the [Installation Guide](https://docs.nginx.com/nginx-service-mesh/get-started/install-with-helm/).
 
-We recommend deploying the mesh with auto-injection disabled globally, using the `--set disableAutoInjection=true` flag. This ensures that Pods are not automatically injected without your consent, especially in system namespaces.
-
-To opt-in a namespace you can label it with `injector.nsm.nginx.com/auto-inject=enabled` or use the flag `--set enabledNamespaces={namespace-1, namespace-2}`.
+To enable automatic sidecar injection, add the following label to a namespace: `injector.nsm.nginx.com/auto-inject=enabled`.

--- a/helm-chart/rancher-files/app-readme.md
+++ b/helm-chart/rancher-files/app-readme.md
@@ -9,12 +9,13 @@ NGINX Service Mesh can integrate with a number of tracing services using OpenTel
 
 ### Using OpenTelemetry
 
-Telemetry can only be enabled by editing the configuration YAML directly in the Rancher UI. When installing NGINX Service Mesh, select the `Edit YAML` option. To enable telemetry, set the `tracing` object to `{}` and fill out the `telemetry` object.
+Telemetry can only be enabled by editing the configuration YAML directly in the Rancher UI. When installing NGINX Service Mesh, select the `Edit YAML` option.
+To enable telemetry, fill out the `telemetry` object.
 The telemetry object expects a `samplerRatio`, and the `host` and `port` of your OTLP gRPC collector.
+
 For example:
 
 ```yaml
-tracing: {}
 telemetry:
   samplerRatio: 0.01
   exporters:
@@ -25,11 +26,4 @@ telemetry:
 
 ### Automatic Sidecar Injection
 
-We recommend deploying the mesh with auto-injection disabled globally. You can then opt-in the namespaces where you would like auto-injection enabled.  This ensures that Pods are not automatically injected without your consent, especially in system namespaces.
-
-To opt-in a namespace you can label it with `injector.nsm.nginx.com/auto-inject=enabled` or provide a list of `enabledNamespaces` in YAML. For example:
-```yaml
-enabledNamespaces:
-- namespace1
-- namespace2
-```
+To enable automatic sidecar injection for all Pods in a namespace, label the namespace with `injector.nsm.nginx.com/auto-inject=enabled`.


### PR DESCRIPTION
### Proposed changes
This PR updates the public documentation now that global auto-injection and `--enabled-namespaces` has been removed. Cleaned up a few unrelated docs in the process. The `Warning`, `Note`, etc. blocks are _really_ overused so I cleaned up several of those.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/test-restore/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
