### PR TITLE
Remove netlify ignore command

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -2,7 +2,6 @@
   base = "docs/"
   publish = "public"
   command = "./scripts/copy-docs.sh && hugo --gc"
-  ignore = "git diff --quiet $COMMIT_REF $CACHED_COMMIT_REF -- ./"
 
 [build.environment]
   HUGO_VERSION = "0.80.0"


### PR DESCRIPTION
The ignore command was ignoring all docs changes, and no staging docs were being rendered. Remove this command to ensure our docs our staged properly.

- [x] I have read the [CONTRIBUTING](https://github.com/test-restore/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
