### PR TITLE
Updating ingress scrape config to remove fixed  pod name

### DIFF
--- a/examples/nginx-plus-ingress-scrape-config.yaml
+++ b/examples/nginx-plus-ingress-scrape-config.yaml
@@ -2,9 +2,9 @@
   kubernetes_sd_configs:
     - role: pod
   relabel_configs:
-    - source_labels: [__meta_kubernetes_pod_container_name]
+    - source_labels: [__meta_kubernetes_pod_annotation_nsm_nginx_com_enable_ingress]
       action: keep
-      regex: nginx-plus-ingress
+      regex: true
     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
       action: keep
       regex: true

--- a/examples/nginx-plus-ingress-scrape-config.yaml
+++ b/examples/nginx-plus-ingress-scrape-config.yaml
@@ -5,6 +5,9 @@
     - source_labels: [__meta_kubernetes_pod_annotation_nsm_nginx_com_enable_ingress]
       action: keep
       regex: true
+    - source_labels: [__meta_kubernetes_pod_annotation_nsm_nginx_com_enable_egress]
+      action: keep
+      regex: true
     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
       action: keep
       regex: true

--- a/examples/prometheus.yaml
+++ b/examples/prometheus.yaml
@@ -77,9 +77,9 @@ data:
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_container_name]
+      - source_labels: [__meta_kubernetes_pod_annotation_nsm_nginx_com_enable_ingress]
         action: keep
-        regex: nginx-plus-ingress
+        regex: true
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/examples/prometheus.yaml
+++ b/examples/prometheus.yaml
@@ -80,6 +80,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_annotation_nsm_nginx_com_enable_ingress]
         action: keep
         regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_nsm_nginx_com_enable_egress]
+        action: keep
+        regex: true
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true


### PR DESCRIPTION
### Proposed changes
Currently, the scrape config only targets pods with the name nginx-plus-ingress. This causes a failure to scrape when deploying ingress with helm, due to the release name being concatenated onto the pod name.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/test-restore/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
