### PR TITLE
Add EKS CSI driver note to docs

### DIFF
--- a/docs/content/get-started/kubernetes-platform/persistent-storage.md
+++ b/docs/content/get-started/kubernetes-platform/persistent-storage.md
@@ -14,7 +14,7 @@ The big three hosted Kubernetes environments (Elastic Kubernetes Service (EKS), 
 {{< important >}}
 **EKS Users:** in Kubernetes v1.23+ the in-tree to container storage interface (CSI) volume migration feature is enabled for EKS.
 This means the Amazon EBS CSI driver must be installed in your cluster in order for persistent storage to work.
-If the CSI driver is not installed prior to installing NGINX Service Mesh, the `PersistentVolumeClaim` required by SPIRE Server get stuck in a pending state and the mesh will fail to install.
+If the CSI driver is not installed prior to installing NGINX Service Mesh, the `PersistentVolumeClaim` required by SPIRE Server gets stuck in a pending state and the mesh will fail to install.
 
 See the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) for instructions on how to install the EBS CSI driver on your EKS cluster.
 If you are unable to install the CSI driver you can disable persistent storage, although this is not recommended for production environments.

--- a/docs/content/get-started/kubernetes-platform/persistent-storage.md
+++ b/docs/content/get-started/kubernetes-platform/persistent-storage.md
@@ -11,6 +11,16 @@ NGINX Service Mesh generates data that needs to persist across restarts and fail
 
 The big three hosted Kubernetes environments (Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), and Google Kubernetes Engine (GKE)) all have built-in persistent storage that NGINX Service Mesh will automatically pick up and use.
 
+{{< important >}}
+**EKS Users:** in Kubernetes v1.23+ the in-tree to container storage interface (CSI) volume migration feature is enabled for EKS.
+This means the Amazon EBS CSI driver must be installed in your cluster in order for persistent storage to work.
+If the CSI driver is not installed prior to installing NGINX Service Mesh, the `PersistentVolumeClaim` required by SPIRE Server get stuck in a pending state and the mesh will fail to install.
+
+See the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) for instructions on how to install the EBS CSI driver on your EKS cluster.
+If you are unable to install the CSI driver you can disable persistent storage, although this is not recommended for production environments.
+Use the `--persistent-storage off` flag if deploying the mesh with `nginx-meshctl` or set the `mtls.persistentStorage` value to `"off"` if using Helm.
+{{< /important >}}
+
 ## Determining Persistent Storage on your Cluster
 
 NGINX Service Mesh will automatically use the default Kubernetes `StorageClass` if it's configured.

--- a/docs/content/get-started/kubernetes-platform/supported-platforms.md
+++ b/docs/content/get-started/kubernetes-platform/supported-platforms.md
@@ -12,7 +12,7 @@ docs: "DOCS-688"
 The Kubernetes platforms listed below will work with NGINX Service Mesh using the Kubernetes versions listed in the [Technical Specifications]({{< ref "/about/tech-specs.md#supported-versions" >}}). Additional Kubernetes platforms may work, although they have not been validated.
 
 - Azure Kubernetes Service (AKS)
-- Elastic Kubernetes Service (EKS)
+- Elastic Kubernetes Service (EKS) -- [Additional setup required]( {{< ref "persistent-storage.md" >}} )
 - Google Kubernetes Engine (GKE) -- [Additional setup required]( {{< ref "gke.md" >}} )
 - Rancher Kubernetes Engine (RKE) -- [Additional setup required]( {{< ref "rke.md" >}} )
 - Kubeadm -- [Additional setup required]( {{< ref "kubeadm.md" >}} )


### PR DESCRIPTION
### Proposed changes
This PR updates the docs with a note regarding the EBS CSI driver requirement for k8s v1.23+ on EKS.
This addresses the issue raised in #237.

Screenshot of main changes (the `Important` block):
![Screenshot 2023-03-27 at 4 33 30 PM](https://user-images.githubusercontent.com/50845045/228090585-044d9d03-986a-40fe-b9f8-2105f33ca287.png)


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/test-restore/nginx-service-mesh/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
